### PR TITLE
Update podspec to use xcframework.

### DIFF
--- a/Adyen3DS2.podspec
+++ b/Adyen3DS2.podspec
@@ -8,9 +8,6 @@ Pod::Spec.new do |spec|
   spec.authors                = { 'Adyen' => 'support@adyen.com' }
   spec.summary                = 'Accept 3D Secure 2.0 payments via Adyen.'
   spec.source                 = { :git => 'https://github.com/adyen/adyen-3ds2-ios.git', :tag => version }
-  spec.vendored_frameworks    = 'Dynamic/Adyen3DS2.framework'
+  spec.vendored_frameworks    = 'XCFramework/Dynamic/Adyen3DS2.xcframework'
   spec.ios.deployment_target  = '10.0'
-  # workaround for binary dependencies, see https://github.com/CocoaPods/CocoaPods/issues/10065
-  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  spec.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
## Summary

Updates the podspec to reference the xcframework, and removes the excluded architectures workaround.