### PR TITLE
Update publich_podspec.yml uses checkout action v4

### DIFF
--- a/.github/workflows/publich_podspec.yml
+++ b/.github/workflows/publich_podspec.yml
@@ -5,7 +5,7 @@ jobs:
   publish:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
Updating the same podspec public action as checkout 
from v2 to v4